### PR TITLE
Implement basic in-memory collection and sequence tracking

### DIFF
--- a/Tests/FountainStoreTests/StoreBasicsTests.swift
+++ b/Tests/FountainStoreTests/StoreBasicsTests.swift
@@ -12,16 +12,20 @@ final class StoreBasicsTests: XCTestCase {
     func test_open_and_snapshot() async throws {
         let tmp = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
         let store = try await FountainStore.open(.init(path: tmp))
-        _ = await store.snapshot()
-        // .todo: assert sequence changes after writes once implemented
-        XCTAssertTrue(true)
+        let start = await store.snapshot()
+        let notes = await store.collection("notes", of: Note.self)
+        try await notes.put(.init(id: UUID(), title: "t", body: "b"))
+        let end = await store.snapshot()
+        XCTAssertGreaterThan(end.sequence, start.sequence)
     }
 
-    func test_collection_compile() async throws {
+    func test_collection_put_get() async throws {
         let tmp = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
         let store = try await FountainStore.open(.init(path: tmp))
         let notes = await store.collection("notes", of: Note.self)
-        _ = try await notes.get(id: UUID())
-        XCTAssertTrue(true)
+        let note = Note(id: UUID(), title: "hello", body: "world")
+        try await notes.put(note)
+        let loaded = try await notes.get(id: note.id)
+        XCTAssertEqual(loaded, note)
     }
 }


### PR DESCRIPTION
## Summary
- introduce simple sequence counter for FountainStore snapshots
- add in-memory Collection actor with put/get/delete stubs
- test snapshot sequence increments and basic put/get

## Testing
- `swift build -c debug`
- `swift test -c debug`


------
https://chatgpt.com/codex/tasks/task_b_68b7340303448333a254bb16f2eb9f51