### PR TITLE
Enforce unique index constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # FountainStore
 
-**Status:** Milestone M4 — metrics & tuning underway; core KV, snapshots, indexing, and metrics counters implemented.
+**Status:** Milestone M4 — metrics & tuning underway; core KV, snapshots, indexing with unique constraints, and metrics counters implemented.
 
 FountainStore is a **pure‑Swift**, embedded, ACID persistence engine for FountainAI.
 It follows an LSM-style architecture (WAL → Memtable → SSTables) with MVCC snapshots,


### PR DESCRIPTION
## Summary
- add CollectionError for unique constraint violations
- enforce uniqueness before writes
- cover unique index enforcement in tests

## Testing
- `swift test -c debug`


------
https://chatgpt.com/codex/tasks/task_b_68b7bf2a4bc483339b11d2ffae953040