### PR TITLE
Add structured logging with configurable sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # FountainStore
 
-**Status:** Milestone M4 — metrics & tuning underway; core KV, snapshots, indexing with unique constraints, and metrics counters implemented.
+**Status:** Milestone M4 — metrics & tuning underway; core KV, snapshots, indexing with unique constraints, metrics counters, and structured logging implemented.
 
 FountainStore is a **pure‑Swift**, embedded, ACID persistence engine for FountainAI.
 It follows an LSM-style architecture (WAL → Memtable → SSTables) with MVCC snapshots,

--- a/Tests/FountainStoreTests/LoggingTests.swift
+++ b/Tests/FountainStoreTests/LoggingTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+import Foundation
+@testable import FountainStore
+
+final class LoggingTests: XCTestCase {
+    struct Item: Codable, Identifiable, Equatable {
+        var id: Int
+        var body: String
+    }
+
+    final class Sink: @unchecked Sendable {
+        private var events: [LogEvent] = []
+        private let lock = NSLock()
+        func append(_ e: LogEvent) {
+            lock.lock(); defer { lock.unlock() }
+            events.append(e)
+        }
+        func snapshot() -> [LogEvent] {
+            lock.lock(); defer { lock.unlock() }
+            return events
+        }
+    }
+
+    func test_operation_logs() async throws {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        let sink = Sink()
+        let store = try await FountainStore.open(.init(path: tmp, logger: { sink.append($0) }))
+        let items = await store.collection("items", of: Item.self)
+        try await items.define(.init(name: "byBody", kind: .unique(\Item.body)))
+        try await items.put(.init(id: 1, body: "a"))
+        _ = try await items.get(id: 1)
+        _ = try await items.byIndex("byBody", equals: "a")
+        _ = try await items.scan()
+        try await items.delete(id: 1)
+        try await items.batch([.put(.init(id: 2, body: "b")), .delete(2)])
+        let events = sink.snapshot()
+        let expected: [LogEvent] = [
+            .put(collection: "items"),
+            .get(collection: "items"),
+            .indexLookup(collection: "items", index: "byBody"),
+            .get(collection: "items"),
+            .scan(collection: "items"),
+            .delete(collection: "items"),
+            .batch(collection: "items", count: 2),
+            .put(collection: "items"),
+            .delete(collection: "items"),
+        ]
+        XCTAssertEqual(events, expected)
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,5 +7,6 @@
 - **Indexes**: Maintained atomically with base writes; unique and multi‑value.
 - **Optional**: FTS (inverted index) and Vector (HNSW).
 - **Metrics**: Operation counters exposed via `metricsSnapshot()` for observability.
+- **Logs**: Structured operation events delivered via `StoreOptions.logger`.
 
 See `agent.md` for implementation steps.


### PR DESCRIPTION
## Summary
- Allow clients to supply a logger closure via `StoreOptions` to receive structured `LogEvent`s
- Record log events for puts, gets, deletes, scans, index lookups and batches
- Document logging and add test coverage for the log stream

## Testing
- `swift test -c debug`

------
https://chatgpt.com/codex/tasks/task_b_68b7c26ae1e48333a539c45c1ed324a1