### PR TITLE
Add metrics reset capability

### DIFF
--- a/Sources/FountainStore/Store.swift
+++ b/Sources/FountainStore/Store.swift
@@ -103,6 +103,12 @@ public actor FountainStore {
         metrics
     }
 
+    public func resetMetrics() -> Metrics {
+        let snap = metrics
+        metrics = Metrics()
+        return snap
+    }
+
     internal func defaultScanLimit() -> Int {
         options.defaultScanLimit
     }

--- a/Tests/FountainStoreTests/MetricsTests.swift
+++ b/Tests/FountainStoreTests/MetricsTests.swift
@@ -41,4 +41,20 @@ final class MetricsTests: XCTestCase {
         XCTAssertEqual(m.puts, 2)
         XCTAssertEqual(m.deletes, 1)
     }
+
+    func test_reset_metrics() async throws {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        let store = try await FountainStore.open(.init(path: tmp))
+        let items = await store.collection("items", of: Item.self)
+        try await items.put(.init(id: 1, body: "a"))
+        let snap = await store.resetMetrics()
+        XCTAssertEqual(snap.puts, 1)
+        let m = await store.metricsSnapshot()
+        XCTAssertEqual(m.puts, 0)
+        XCTAssertEqual(m.gets, 0)
+        XCTAssertEqual(m.deletes, 0)
+        XCTAssertEqual(m.scans, 0)
+        XCTAssertEqual(m.indexLookups, 0)
+        XCTAssertEqual(m.batches, 0)
+    }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,7 +6,7 @@
 - **Isolation**: MVCC snapshots keyed by sequence numbers.
 - **Indexes**: Maintained atomically with base writes; unique and multi‑value with equality and prefix scans.
 - **Optional**: FTS (inverted index) and Vector (HNSW).
-- **Metrics**: Operation counters exposed via `metricsSnapshot()` for observability.
+- **Metrics**: Operation counters exposed via `metricsSnapshot()` and reset with `resetMetrics()` for observability.
 - **Logs**: Structured operation events delivered via `StoreOptions.logger`.
 - **Configuration**: Tunable defaults such as `StoreOptions.defaultScanLimit` for range and index scans.
 


### PR DESCRIPTION
## Summary
- allow resetting operation metrics for incremental observability
- document metrics reset behaviour
- test that metrics can be reset to zero

## Testing
- `swift test -c debug`


------
https://chatgpt.com/codex/tasks/task_b_68b7cacfa8d483339a97b20c171b7de4