### PR TITLE
Add basic full-text search inverted index

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,6 @@ let package = Package(
         .target(name: "FountainStoreCore"),
         .target(name: "FountainFTS", dependencies: ["FountainStoreCore"]),
         .target(name: "FountainVector", dependencies: ["FountainStoreCore"]),
-        .testTarget(name: "FountainStoreTests", dependencies: ["FountainStore"]),
+        .testTarget(name: "FountainStoreTests", dependencies: ["FountainStore", "FountainFTS"]),
     ]
 )

--- a/Sources/FountainFTS/FTS.swift
+++ b/Sources/FountainFTS/FTS.swift
@@ -3,11 +3,60 @@
 //  FTS.swift
 //  FountainFTS
 //
-//  Placeholder for inverted index (BM25/scoring to be added in M5).
-//
+//  Basic inverted index for optional full‑text search module.
+//  Tokenization is whitespace and punctuation based. Scoring/BM25 to follow.
 
 import Foundation
 
 public struct FTSIndex: Sendable, Hashable {
+    private var postings: [String: Set<String>] = [:]
+    private var docTokens: [String: Set<String>] = [:]
+
     public init() {}
+
+    public mutating func add(docID: String, text: String) {
+        let tokens = tokenize(text)
+        docTokens[docID] = tokens
+        for t in tokens {
+            postings[t, default: []].insert(docID)
+        }
+    }
+
+    public mutating func remove(docID: String) {
+        guard let tokens = docTokens.removeValue(forKey: docID) else { return }
+        for t in tokens {
+            postings[t]?.remove(docID)
+            if postings[t]?.isEmpty == true { postings[t] = nil }
+        }
+    }
+
+    public func search(_ query: String) -> [String] {
+        let tokens = Array(tokenize(query))
+        guard let first = tokens.first else { return [] }
+        var result = postings[first] ?? []
+        for t in tokens.dropFirst() {
+            result.formIntersection(postings[t] ?? [])
+            if result.isEmpty { break }
+        }
+        return Array(result)
+    }
+
+    private func tokenize(_ text: String) -> Set<String> {
+        let separators = CharacterSet.alphanumerics.inverted
+        let parts = text.lowercased().components(separatedBy: separators)
+        return Set(parts.filter { !$0.isEmpty })
+    }
+
+    public static func == (lhs: FTSIndex, rhs: FTSIndex) -> Bool {
+        lhs.postings == rhs.postings
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(postings.count)
+        for (token, ids) in postings.sorted(by: { $0.key < $1.key }) {
+            hasher.combine(token)
+            hasher.combine(ids.count)
+            for id in ids.sorted() { hasher.combine(id) }
+        }
+    }
 }

--- a/Tests/FountainStoreTests/FTSTests.swift
+++ b/Tests/FountainStoreTests/FTSTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+@testable import FountainFTS
+
+final class FTSTests: XCTestCase {
+    func test_basic_index_and_search() {
+        var idx = FTSIndex()
+        idx.add(docID: "1", text: "hello world")
+        idx.add(docID: "2", text: "hello swift")
+        XCTAssertEqual(Set(idx.search("hello")), ["1", "2"])
+        XCTAssertEqual(Set(idx.search("world")), ["1"])
+        XCTAssertTrue(idx.search("swift world").isEmpty)
+    }
+
+    func test_remove_document() {
+        var idx = FTSIndex()
+        idx.add(docID: "1", text: "hello world")
+        idx.add(docID: "2", text: "hello swift")
+        idx.remove(docID: "1")
+        XCTAssertEqual(Set(idx.search("hello")), ["2"])
+        XCTAssertTrue(idx.search("world").isEmpty)
+    }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -5,4 +5,4 @@
 - [x] M2: Compaction & snapshots
 - [x] M3: Transactions & indexes
 - [x] M4: Observability & Tuning – metrics counters, structured logs, configuration knobs.
-- [ ] M5: Optional Modules – FTS (inverted index, analyzers, BM25) and Vector (HNSW with cosine/L2).
+- [ ] M5: Optional Modules – basic FTS inverted index; analyzers, BM25, and Vector (HNSW with cosine/L2) pending.


### PR DESCRIPTION
## Summary
- introduce simple FTSIndex supporting add/remove/search
- test inverted index behavior
- note partial FTS progress in roadmap

## Testing
- `swift test -c debug`


------
https://chatgpt.com/codex/tasks/task_b_68b7cdbae3988333bbf15b6b7fc1272d