### PR TITLE
feat(vector): support cosine distance

### DIFF
--- a/Sources/FountainVector/HNSW.swift
+++ b/Sources/FountainVector/HNSW.swift
@@ -23,25 +23,50 @@ public struct HNSWIndex: Sendable, Hashable {
         vectors[id] = nil
     }
 
-    /// Returns the `k` nearest identifiers to the query using L2 distance.
-    public func search(_ query: [Double], k: Int) -> [String] {
+    public enum DistanceMetric: Sendable {
+        case l2
+        case cosine
+    }
+
+    /// Returns the `k` nearest identifiers to the query using the specified metric.
+    /// Defaults to L2 distance when no metric is provided.
+    public func search(_ query: [Double], k: Int, metric: DistanceMetric = .l2) -> [String] {
         var scored: [(String, Double)] = []
         scored.reserveCapacity(vectors.count)
         for (id, vec) in vectors {
             guard vec.count == query.count else { continue }
-            let dist = l2(query, vec)
+            let dist = distance(query, vec, metric: metric)
             scored.append((id, dist))
         }
         scored.sort { $0.1 < $1.1 }
         return scored.prefix(k).map { $0.0 }
     }
 
-    private func l2(_ a: [Double], _ b: [Double]) -> Double {
-        var sum = 0.0
-        for i in 0..<a.count {
-            let d = a[i] - b[i]
-            sum += d * d
+    private func distance(_ a: [Double], _ b: [Double], metric: DistanceMetric) -> Double {
+        switch metric {
+        case .l2:
+            var sum = 0.0
+            for i in 0..<a.count {
+                let d = a[i] - b[i]
+                sum += d * d
+            }
+            return sum
+        case .cosine:
+            return 1.0 - cosine(a, b)
         }
-        return sum
+    }
+
+    private func cosine(_ a: [Double], _ b: [Double]) -> Double {
+        var dot = 0.0
+        var na = 0.0
+        var nb = 0.0
+        for i in 0..<a.count {
+            dot += a[i] * b[i]
+            na += a[i] * a[i]
+            nb += b[i] * b[i]
+        }
+        let denom = (na.squareRoot() * nb.squareRoot())
+        if denom == 0 { return 0 }
+        return dot / denom
     }
 }

--- a/Tests/FountainStoreTests/VectorTests.swift
+++ b/Tests/FountainStoreTests/VectorTests.swift
@@ -19,4 +19,12 @@ final class VectorTests: XCTestCase {
         let res = idx.search([0.0, 0.0], k: 1)
         XCTAssertEqual(res, ["b"])
     }
+
+    func test_cosine_distance() {
+        var idx = HNSWIndex()
+        idx.add(id: "a", vector: [1.0, 0.0])
+        idx.add(id: "b", vector: [0.0, 1.0])
+        let res = idx.search([1.0, 0.0], k: 2, metric: .cosine)
+        XCTAssertEqual(res, ["a", "b"])
+    }
 }


### PR DESCRIPTION
## Summary
- expand vector index API to search with L2 or cosine distance
- add coverage for cosine metric search

## Testing
- `swift build -c debug`
- `swift test -c debug`


------
https://chatgpt.com/codex/tasks/task_b_68b7d18349c08333b71c67e896d8742f