### PR TITLE
feat: allow custom FTS analyzers

### DIFF
--- a/Tests/FountainStoreTests/OptionalModulesIntegrationTests.swift
+++ b/Tests/FountainStoreTests/OptionalModulesIntegrationTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import FountainStore
+import FountainFTS
 
 final class OptionalModulesIntegrationTests: XCTestCase {
     struct TextDoc: Codable, Identifiable, Equatable {
@@ -23,6 +24,17 @@ final class OptionalModulesIntegrationTests: XCTestCase {
         XCTAssertEqual(res, [1])
     }
 
+    func test_fts_custom_analyzer() async throws {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        let store = try await FountainStore.open(.init(path: tmp))
+        let docs = await store.collection("docs", of: TextDoc.self)
+        let analyzer = FTSIndex.stopwordAnalyzer(["the"])
+        try await docs.define(.init(name: "fts", kind: .fts(\TextDoc.text, analyzer: analyzer)))
+        try await docs.put(.init(id: 1, text: "the quick brown fox"))
+        let res = try await docs.searchText("fts", query: "the")
+        XCTAssertTrue(res.isEmpty)
+    }
+
     func test_vector_index_search() async throws {
         let tmp = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
         let store = try await FountainStore.open(.init(path: tmp))
@@ -31,6 +43,17 @@ final class OptionalModulesIntegrationTests: XCTestCase {
         try await items.put(.init(id: "a", embedding: [0.0, 0.0]))
         try await items.put(.init(id: "b", embedding: [1.0, 1.0]))
         let res = try await items.vectorSearch("vec", query: [0.1, 0.1], k: 1).map { $0.id }
+        XCTAssertEqual(res, ["a"])
+    }
+
+    func test_vector_index_search_cosine() async throws {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        let store = try await FountainStore.open(.init(path: tmp))
+        let items = await store.collection("items", of: VecDoc.self)
+        try await items.define(.init(name: "vec", kind: .vector(\VecDoc.embedding)))
+        try await items.put(.init(id: "a", embedding: [1.0, 0.0]))
+        try await items.put(.init(id: "b", embedding: [0.0, 1.0]))
+        let res = try await items.vectorSearch("vec", query: [1.0, 0.0], k: 1, metric: .cosine).map { $0.id }
         XCTAssertEqual(res, ["a"])
     }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,6 +6,7 @@
 - **Isolation**: MVCC snapshots keyed by sequence numbers.
 - **Indexes**: Maintained atomically with base writes; unique and multi‑value with equality and prefix scans.
 - **Optional**: FTS (inverted index with pluggable analyzers) and Vector (HNSW with cosine/L2 metrics).
+- **FTS Analyzer**: Collections can supply custom analyzers when defining indexes using `.fts(\\Type.field, analyzer: ...)`.
 - **Metrics**: Operation counters (puts, gets, deletes, scans, index lookups, batches, histories) exposed via `metricsSnapshot()` and reset with `resetMetrics()` for observability.
 - **Logs**: Structured operation events delivered via `StoreOptions.logger`.
 - **Configuration**: Tunable defaults such as `StoreOptions.defaultScanLimit` for range and index scans.

--- a/docs/TESTPLAN.md
+++ b/docs/TESTPLAN.md
@@ -17,6 +17,10 @@
 ## Observability
 - Operation metrics counters and history logging
 
+## Optional Modules
+- FTS search with BM25 ranking and custom analyzers
+- Vector search via HNSW using L2 and cosine metrics
+
 ## Performance (later)
 - Write amplification tracking
 - Bloom false‑positive sampling


### PR DESCRIPTION
## Summary
- allow collections to define FTS indexes with custom analyzers
- cover FTS stopword analyzers and cosine vector search in integration tests
- document optional-module testing and analyzer configuration
- drop `withoutActuallyEscaping` wrapper from FTS analyzer to avoid runtime failure

## Testing
- `swift build -c debug`
- `swift test -c debug`


------
https://chatgpt.com/codex/tasks/task_b_68b7d710c2fc833395e1038b6fcddeb9