### PR TITLE
feat(fts): add optional result limit

### DIFF
--- a/Sources/FountainFTS/FTS.swift
+++ b/Sources/FountainFTS/FTS.swift
@@ -42,7 +42,7 @@ public struct FTSIndex: Sendable, Hashable {
         }
     }
 
-    public func search(_ query: String) -> [String] {
+    public func search(_ query: String, limit: Int? = nil) -> [String] {
         let tokens = analyze(query)
         guard let first = tokens.first else { return [] }
         var result = postings[first].map { Set($0.keys) } ?? Set<String>()
@@ -57,6 +57,9 @@ public struct FTSIndex: Sendable, Hashable {
             scored.append((doc, bm25(tokens, doc)))
         }
         scored.sort { $0.1 > $1.1 }
+        if let limit = limit {
+            return scored.prefix(limit).map { $0.0 }
+        }
         return scored.map { $0.0 }
     }
 

--- a/Sources/FountainStore/Store.swift
+++ b/Sources/FountainStore/Store.swift
@@ -467,12 +467,12 @@ public actor Collection<C: Codable & Identifiable> where C.ID: Codable & Hashabl
         }
     }
 
-    public func searchText(_ name: String, query: String) async throws -> [C] {
+    public func searchText(_ name: String, query: String, limit: Int? = nil) async throws -> [C] {
         await store.record(.indexLookup)
         await store.log(.indexLookup(collection: self.name, index: name))
         guard let storage = indexes[name] else { return [] }
         guard case .fts(let idx) = storage else { return [] }
-        let ids = idx.index.search(query)
+        let ids = idx.index.search(query, limit: limit)
         var res: [C] = []
         for doc in ids {
             if let real = idx.idMap[doc], let val = try await get(id: real) {

--- a/Tests/FountainStoreTests/FTSTests.swift
+++ b/Tests/FountainStoreTests/FTSTests.swift
@@ -28,6 +28,14 @@ final class FTSTests: XCTestCase {
         XCTAssertEqual(res, ["A", "B"])
     }
 
+    func test_search_limit() {
+        var idx = FTSIndex()
+        idx.add(docID: "1", text: "hello world")
+        idx.add(docID: "2", text: "hello hello world")
+        let res = idx.search("hello", limit: 1)
+        XCTAssertEqual(res, ["2"])
+    }
+
     func test_stopword_analyzer() {
         let stopwords: Set<String> = ["the", "and"]
         var idx = FTSIndex(analyzer: FTSIndex.stopwordAnalyzer(stopwords))

--- a/Tests/FountainStoreTests/OptionalModulesIntegrationTests.swift
+++ b/Tests/FountainStoreTests/OptionalModulesIntegrationTests.swift
@@ -24,6 +24,17 @@ final class OptionalModulesIntegrationTests: XCTestCase {
         XCTAssertEqual(res, [1])
     }
 
+    func test_fts_index_search_limit() async throws {
+        let tmp = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
+        let store = try await FountainStore.open(.init(path: tmp))
+        let docs = await store.collection("docs", of: TextDoc.self)
+        try await docs.define(.init(name: "fts", kind: .fts(\TextDoc.text)))
+        try await docs.put(.init(id: 1, text: "hello world"))
+        try await docs.put(.init(id: 2, text: "hello hello world"))
+        let res = try await docs.searchText("fts", query: "hello", limit: 1).map { $0.id }
+        XCTAssertEqual(res, [2])
+    }
+
     func test_fts_custom_analyzer() async throws {
         let tmp = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(UUID().uuidString)
         let store = try await FountainStore.open(.init(path: tmp))

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -7,6 +7,7 @@
 - **Indexes**: Maintained atomically with base writes; unique and multi‑value with equality and prefix scans.
 - **Optional**: FTS (inverted index with pluggable analyzers) and Vector (HNSW with cosine/L2 metrics).
 - **FTS Analyzer**: Collections can supply custom analyzers when defining indexes using `.fts(\\Type.field, analyzer: ...)`.
+- **FTS Search**: BM25-ranked results with an optional result limit via `searchText`.
 - **Metrics**: Operation counters (puts, gets, deletes, scans, index lookups, batches, histories) exposed via `metricsSnapshot()` and reset with `resetMetrics()` for observability.
 - **Logs**: Structured operation events delivered via `StoreOptions.logger`.
 - **Configuration**: Tunable defaults such as `StoreOptions.defaultScanLimit` for range and index scans.


### PR DESCRIPTION
## Summary
- allow FTS search to cap number of returned hits
- expose optional limit on `searchText` API
- add coverage for limited search and document update

## Testing
- `swift test -c debug`


------
https://chatgpt.com/codex/tasks/task_b_68b7d9451b7c83339b1793b648567c6d